### PR TITLE
chore: add package support metadata

### DIFF
--- a/.changeset/silent-rivers-provide.md
+++ b/.changeset/silent-rivers-provide.md
@@ -1,0 +1,5 @@
+---
+"maath": patch
+---
+
+Add npm package support metadata.

--- a/packages/maath/package.json
+++ b/packages/maath/package.json
@@ -2,6 +2,15 @@
   "name": "maath",
   "version": "0.10.8",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/maath.git",
+    "directory": "packages/maath"
+  },
+  "homepage": "https://github.com/pmndrs/maath#readme",
+  "bugs": {
+    "url": "https://github.com/pmndrs/maath/issues"
+  },
   "main": "dist/maath.cjs.js",
   "module": "dist/maath.esm.js",
   "types": "dist/maath.cjs.d.ts",


### PR DESCRIPTION
## Summary
- add npm `repository`, `homepage`, and `bugs.url` metadata for the published `maath` package
- point the metadata at the existing GitHub repository and issue tracker
- leave runtime code, dependencies, version, and build configuration unchanged

## Validation
- `node -e "const p=require('./packages/maath/package.json'); ..."`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./packages/maath`